### PR TITLE
Verbessere die Auswahl von Lampen

### DIFF
--- a/src/lamps/LampsContainer.java
+++ b/src/lamps/LampsContainer.java
@@ -3,6 +3,7 @@ package lamps;
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.BorderPane;
 
@@ -14,6 +15,9 @@ public class LampsContainer extends BorderPane {
     private final ObservableList<Lamp> lamps = FXCollections.observableArrayList();
 
     public LampsContainer() {
+        // accept focus
+        setFocusTraversable(true);
+
         // bind the content to the lamps
         Bindings.bindContent(getChildren(), lamps);
 
@@ -41,6 +45,8 @@ public class LampsContainer extends BorderPane {
         });
 
         setOnMouseClicked(event -> {
+            requestFocus();
+
             var target = event.getTarget();
             if (event.getButton() == MouseButton.PRIMARY && target instanceof Lamp) {
                 // Remove the lamp if it was already selected
@@ -51,6 +57,15 @@ public class LampsContainer extends BorderPane {
                     selectedLamps.add((Lamp) target);
                 else
                     selectedLamps.setAll((Lamp) target);
+            }
+        });
+
+        setOnKeyPressed(event -> {
+            if (event.isControlDown() && event.getCode() == KeyCode.A) {
+                if (event.isShiftDown())
+                    selectedLamps.clear();
+                else
+                    selectedLamps.setAll(lamps);
             }
         });
     }

--- a/src/lamps/LampsContainer.java
+++ b/src/lamps/LampsContainer.java
@@ -49,14 +49,13 @@ public class LampsContainer extends BorderPane {
 
             var target = event.getTarget();
             if (event.getButton() == MouseButton.PRIMARY && target instanceof Lamp) {
-                // Remove the lamp if it was already selected
-                if (selectedLamps.remove(target))
-                    return;
-
-                if (event.isControlDown())
-                    selectedLamps.add((Lamp) target);
-                else
+                if (event.isControlDown()) {
+                    // Remove the lamp if it was already selected
+                    if (!selectedLamps.remove(target))
+                        selectedLamps.add((Lamp) target);
+                } else {
                     selectedLamps.setAll((Lamp) target);
+                }
             } else {
                 selectedLamps.clear();
             }

--- a/src/lamps/LampsContainer.java
+++ b/src/lamps/LampsContainer.java
@@ -57,6 +57,8 @@ public class LampsContainer extends BorderPane {
                     selectedLamps.add((Lamp) target);
                 else
                     selectedLamps.setAll((Lamp) target);
+            } else {
+                selectedLamps.clear();
             }
         });
 

--- a/src/lamps/LampsContainer.java
+++ b/src/lamps/LampsContainer.java
@@ -1,5 +1,6 @@
 package lamps;
 
+import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.input.MouseButton;
@@ -8,19 +9,24 @@ import javafx.scene.layout.BorderPane;
 public class LampsContainer extends BorderPane {
     private Lamp draggingLamp = null;
 
-    private ObservableList<Lamp> selectedLamps = FXCollections.observableArrayList();
+    private final ObservableList<Lamp> selectedLamps = FXCollections.observableArrayList();
+
+    private final ObservableList<Lamp> lamps = FXCollections.observableArrayList();
 
     public LampsContainer() {
+        // bind the content to the lamps
+        Bindings.bindContent(getChildren(), lamps);
+
         setOnMousePressed(event -> {
             var target = event.getTarget();
-            if(event.getButton() == MouseButton.PRIMARY && target instanceof Lamp) {
+            if (event.getButton() == MouseButton.PRIMARY && target instanceof Lamp) {
                 draggingLamp = (Lamp) target;
                 event.consume();
             }
         });
 
         setOnMouseReleased(event -> {
-            if(event.getButton() == MouseButton.PRIMARY && draggingLamp != null) {
+            if (event.getButton() == MouseButton.PRIMARY && draggingLamp != null) {
                 event.consume();
                 draggingLamp = null;
             }
@@ -38,18 +44,23 @@ public class LampsContainer extends BorderPane {
             var target = event.getTarget();
             if (event.getButton() == MouseButton.PRIMARY && target instanceof Lamp) {
                 // Remove the lamp if it was already selected
-                if(selectedLamps.remove(target))
+                if (selectedLamps.remove(target))
                     return;
 
-                if(event.isControlDown())
-                    selectedLamps.add((Lamp)target);
+                if (event.isControlDown())
+                    selectedLamps.add((Lamp) target);
                 else
-                    selectedLamps.setAll((Lamp)target);
+                    selectedLamps.setAll((Lamp) target);
             }
         });
     }
 
+
     public ObservableList<Lamp> getSelectedLamps() {
         return selectedLamps;
+    }
+
+    public ObservableList<Lamp> getLamps() {
+        return lamps;
     }
 }

--- a/src/lamps/Main.java
+++ b/src/lamps/Main.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 
 public class Main extends Application {
     private final ObservableList<Group> groups = FXCollections.observableArrayList();
-    private final ObservableList<Lamp> lamps = FXCollections.observableArrayList();
+    //private final ObservableList<Lamp> lamps = FXCollections.observableArrayList();
 
     private final SimpleObjectProperty<Group> selectedGroup = new SimpleObjectProperty<>(null);
 
@@ -31,11 +31,10 @@ public class Main extends Application {
     @Override
     public void start(Stage primaryStage) {
         lampsContainer = new LampsContainer();
-        Bindings.bindContent(lampsContainer.getChildren(), lamps);
 
         // Bind the selected property of all lamps that get added
         var selectedLamps = lampsContainer.getSelectedLamps();
-        lamps.addListener((ListChangeListener<Lamp>) c -> {
+        lampsContainer.getLamps().addListener((ListChangeListener<Lamp>) c -> {
             while(c.next()) {
                 for (var lamp : c.getAddedSubList()) {
                     lamp.selectedProperty().bind(Bindings.createBooleanBinding(
@@ -99,13 +98,13 @@ public class Main extends Application {
         var addButton = new Button("Neu");
         addButton.setOnAction(event -> {
             var lamp = new Lamp();
-            lamps.add(lamp);
+            lampsContainer.getLamps().add(lamp);
         });
 
         var removeButton = new Button("Entfernen");
         removeButton.disableProperty().bind(noLamp);
         removeButton.setOnAction(event -> {
-            lamps.removeAll(lampsContainer.getSelectedLamps());
+            lampsContainer.getLamps().removeAll(lampsContainer.getSelectedLamps());
             lampsContainer.getSelectedLamps().clear();
         });
 
@@ -182,7 +181,7 @@ public class Main extends Application {
         toggleButton.disableProperty().bind(noGroup);
         toggleButton.setOnAction(event -> {
             var selectedGroups = listView.getSelectionModel().getSelectedItems();
-            var selectedLamps = lamps.stream()
+            var selectedLamps = lampsContainer.getLamps().stream()
                     .filter(lamp -> selectedGroups.contains(lamp.getGroup()))
                     .collect(Collectors.toList());
 
@@ -213,7 +212,7 @@ public class Main extends Application {
             groupsToRemove.forEach(groups::remove);
 
             // remove all lamps from those groups
-            lamps.stream()
+            lampsContainer.getLamps().stream()
                     .filter(lamp -> groupsToRemove.contains(lamp.getGroup()))
                     .forEach(lamp -> lamp.setGroup(null));
         });


### PR DESCRIPTION
* [x] Tastenkombinationen für das Aus- und Abwählen aller Lampen
* [x] Abwählen aller Lampen beim Klicken auf freien Raum
* [x] Bei Mehrfachauswahl: beim Klicken auf eine Lampe ohne `Strg` soll nur diese augewählt werden.