### PR TITLE
Aufräumen von LampsContainer

### DIFF
--- a/src/lamps/LampsContainer.java
+++ b/src/lamps/LampsContainer.java
@@ -2,6 +2,7 @@ package lamps;
 
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
@@ -11,13 +12,19 @@ import javafx.scene.layout.BorderPane;
  * Die Fläche des Fensters, welche alle Lampen enthält
  */
 public class LampsContainer extends BorderPane {
-    /** die zurzeit bewegte Lampe */
+    /**
+     * die zurzeit bewegte Lampe
+     */
     private Lamp draggingLamp = null;
 
-    /** die ausgewählten Lampen */
+    /**
+     * die ausgewählten Lampen
+     */
     private final ObservableList<Lamp> selectedLamps = FXCollections.observableArrayList();
 
-    /** alle Lampen in diesem Container */
+    /**
+     * alle Lampen in diesem Container
+     */
     private final ObservableList<Lamp> lamps = FXCollections.observableArrayList();
 
     public LampsContainer() {
@@ -27,6 +34,73 @@ public class LampsContainer extends BorderPane {
         // bind the content to the lamps
         Bindings.bindContent(getChildren(), lamps);
 
+        // Drag n' Drop der Lampen ermöglichen
+        setupDragAndDrop();
+
+        // Auswahl einrichten
+        setupSelection();
+
+        // Tastenkombinationen für LampsContainer
+        setOnKeyPressed(event -> {
+            // Strg + A
+            if (event.isControlDown() && event.getCode() == KeyCode.A) {
+                if (event.isShiftDown()) // + Umschalt -> Auswahl löschen
+                    selectedLamps.clear();
+                else // sonst: alles auswählen
+                    selectedLamps.setAll(lamps);
+            }
+        });
+    }
+
+    /**
+     * Richtet das Auswahlverhalten ein
+     */
+    private void setupSelection() {
+        // Bind the selected property of all lamps that get added
+        lamps.addListener((ListChangeListener<Lamp>) c -> { // Beim hinzufügen und entfernen von Lampen
+            while (c.next()) {
+                for (var lamp : c.getAddedSubList()) {
+                    // Wenn eine Lampe hinzugefügt wird, wird die selected-Eigenschaft daran gebunden,
+                    // ob die Lampe in der selectedLamps-Liste ist
+                    lamp.selectedProperty().bind(Bindings.createBooleanBinding(
+                            () -> selectedLamps.contains(lamp),
+                            selectedLamps
+                    ));
+                }
+
+                for (var lamp : c.getRemoved()) {
+                    // Wenn eine Lampe entfernt wird, wird diese Bindung gelöst
+                    lamp.selectedProperty().unbind();
+                }
+            }
+        });
+
+        // Beim einfachen Klicken:
+        setOnMouseClicked(event -> {
+            requestFocus(); // Tastaturfokus auf dieses Objekt bringen
+
+            // das Objekt, auf das geklickt wurde
+            var target = event.getTarget();
+
+            // WENN: linke Maustaste UND kein Doppelklick UND es wurde auf eine Lampe geklickt
+            if (event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 1 && target instanceof Lamp) {
+                if (event.isControlDown()) { // + Strg-Taste: Mehrfachauswahl
+                    // Remove the lamp if it was already selected
+                    if (!selectedLamps.remove(target))
+                        selectedLamps.add((Lamp) target);
+                } else { // sonst: nur diese Lampe auswählen
+                    selectedLamps.setAll((Lamp) target);
+                }
+            } else { // wenn auf leere Fläche geklickt wurde:
+                selectedLamps.clear(); // auswahl leeren
+            }
+        });
+    }
+
+    /**
+     * Ermöglicht das verschieben der Lampen mithilfe der Maus
+     */
+    private void setupDragAndDrop() {
         // wenn die Maus auf einer Lampe runtergedrückt wird, wird diese verschoben
         setOnMousePressed(event -> {
             var target = event.getTarget();
@@ -52,42 +126,11 @@ public class LampsContainer extends BorderPane {
                 draggingLamp.setCenterY(event.getY());
             }
         });
-
-        // Beim einfachen Klicken:
-        setOnMouseClicked(event -> {
-            requestFocus(); // Tastaturfokus auf dieses Objekt bringen
-
-            // das Objekt, auf das geklickt wurde
-            var target = event.getTarget();
-
-            // WENN: linke Maustaste UND es wurde auf eine Lampe geklickt
-            if (event.getButton() == MouseButton.PRIMARY && target instanceof Lamp) {
-                if (event.isControlDown()) { // + Strg-Taste: Mehrfachauswahl
-                    // Remove the lamp if it was already selected
-                    if (!selectedLamps.remove(target))
-                        selectedLamps.add((Lamp) target);
-                } else { // sonst: nur diese Lampe auswählen
-                    selectedLamps.setAll((Lamp) target);
-                }
-            } else { // wenn auf leere Fläche geklickt wurde:
-                selectedLamps.clear(); // auswahl leeren
-            }
-        });
-
-        // Tastenkombinationen
-        setOnKeyPressed(event -> {
-            // Strg + A
-            if (event.isControlDown() && event.getCode() == KeyCode.A) {
-                if (event.isShiftDown()) // + Umschalt -> Auswahl löschen
-                    selectedLamps.clear();
-                else // sonst: alles auswählen
-                    selectedLamps.setAll(lamps);
-            }
-        });
     }
 
     /**
      * Gibt die ausgewählten Lampen zurück
+     *
      * @return die ausgewählten Lampen
      */
     public ObservableList<Lamp> getSelectedLamps() {
@@ -96,6 +139,7 @@ public class LampsContainer extends BorderPane {
 
     /**
      * Gibt die Lampen in diesem Container zurück
+     *
      * @return die Lampen
      */
     public ObservableList<Lamp> getLamps() {

--- a/src/lamps/Main.java
+++ b/src/lamps/Main.java
@@ -40,23 +40,6 @@ public class Main extends Application {
     public void start(Stage primaryStage) {
         lampsContainer = new LampsContainer();
 
-        // Bind the selected property of all lamps that get added
-        var selectedLamps = lampsContainer.getSelectedLamps();
-        lampsContainer.getLamps().addListener((ListChangeListener<Lamp>) c -> {
-            while(c.next()) {
-                for (var lamp : c.getAddedSubList()) {
-                    lamp.selectedProperty().bind(Bindings.createBooleanBinding(
-                            () -> selectedLamps.contains(lamp),
-                            selectedLamps
-                    ));
-                }
-
-                for (var lamp : c.getRemoved()) {
-                    lamp.selectedProperty().unbind();
-                }
-            }
-        });
-
         // Toolbar und Gruppenpanel erstellen
         var toolbar = createToolbar();
         var groupsPane = createGroupsPane();


### PR DESCRIPTION
- der Inhalt des Konstruktors wurde auf mehrere Methoden verteilt
- die Bindung der `selected`-Eigenschaft der Lampen wurde nach `LampsContainer` verschoben