### PR TITLE
Beobachte die Gruppen der ausgewählten Lampen

### DIFF
--- a/src/lamps/GroupsChangeObservable.java
+++ b/src/lamps/GroupsChangeObservable.java
@@ -1,0 +1,63 @@
+package lamps;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+
+import java.util.ArrayList;
+
+/**
+ * Beobachtet eine Liste von Lampen und löst eine Änderung aus, wenn sich die Gruppe einer Lampe geändert hat
+ */
+public class GroupsChangeObservable implements Observable, InvalidationListener {
+    private ArrayList<InvalidationListener> listeners = new ArrayList<>();
+
+    /**
+     * Erstellt eine neue Instanz und beobachtet die Liste und die Gruppen der enthaltenen Lampen
+     * @param lamps die Liste der Lampen
+     */
+    public GroupsChangeObservable(ObservableList<Lamp> lamps) {
+        lamps.addListener((ListChangeListener<Lamp>) c -> {
+            while (c.next()) {
+                // Neue Lampen beobachten
+                for (var lamp : c.getAddedSubList()) {
+                    lamp.groupProperty().addListener(GroupsChangeObservable.this);
+                }
+
+                // Entfernte Lampen nicht mehr beoachten
+                for (var lamp : c.getRemoved()) {
+                    lamp.groupProperty().removeListener(GroupsChangeObservable.this);
+                }
+            }
+        });
+    }
+
+    /**
+     * Wird aufgerufen, wenn sich die Gruppe einer Lampe geändert hat
+     * @param observable die Lampe
+     */
+    @Override
+    public void invalidated(Observable observable) {
+        for (var listener : listeners) {
+            listener.invalidated(this);
+        }
+    }
+
+    /**
+     * Fügt einen {@link InvalidationListener} hinzu
+     */
+    @Override
+    public void addListener(InvalidationListener listener) {
+        if (!listeners.contains(listener)) // wenn nicht schon vorhanden
+            listeners.add(listener);
+    }
+
+    /**
+     * Entfernt einen {@link InvalidationListener}
+     */
+    @Override
+    public void removeListener(InvalidationListener listener) {
+        listeners.remove(listener);
+    }
+}

--- a/src/lamps/Main.java
+++ b/src/lamps/Main.java
@@ -86,6 +86,9 @@ public class Main extends Application {
         // conditions
         var noLamp = Bindings.isEmpty(lampsContainer.getSelectedLamps());
 
+        // löst eine Änderung aus, wenn sich die Gruppe einer ausgewählten Lampe geändert hat
+        var groupsChange = new GroupsChangeObservable(lampsContainer.getSelectedLamps());
+
         // toggle
 
         // schaltet alle ausgewählten Lampen um
@@ -128,7 +131,7 @@ public class Main extends Application {
             var lamps = lampsContainer.getSelectedLamps();
 
             return group == null || lamps.isEmpty() || lamps.stream().allMatch(lamp -> lamp.getGroup() == group);
-        }, selectedGroup, lampsContainer.getSelectedLamps()));
+        }, selectedGroup, lampsContainer.getSelectedLamps(), groupsChange));
 
         // entfernt alle ausgewählten Lampen aus ihren Gruppen
         var removeFromGroupButton = new Button("Aus Gruppe entfernen");
@@ -141,7 +144,7 @@ public class Main extends Application {
         // disable the button if none of the selected lamps have a group
         removeFromGroupButton.disableProperty().bind(Bindings.createBooleanBinding(
                 () -> lampsContainer.getSelectedLamps().stream().allMatch(lamp -> lamp.getGroup() == null),
-                lampsContainer.getSelectedLamps()
+                lampsContainer.getSelectedLamps(), groupsChange
         ));
 
         // create the toolbar


### PR DESCRIPTION
Um den Zustand des "Zur Gruppe hinzufügen"- und des "Aus Gruppe entfernen"-Knopfes richtig zu bestimmen, muss auf die Gruppen der aktuell ausgewählten Lampen geachtet werden. So muss der "Zur Gruppe hinzufügen"-Knopf deaktiviert werden wenn alle ausgewählten Lampen zur Gruppe hinzugefügt wurden.

Um dies zu ermöglichem wurde `GroupsChangeObservable` hinzugefügt, welches diese Rolle übernimmt und eine Änderung auslöst, wenn sich die Gruppe einer ausgewählten Lampe geändert hat.

fixes #15 